### PR TITLE
chore: add .gitignore for Node.js and GitHub Actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Node.js
+node_modules
+npm-debug.log
+yarn-error.log
+
+# Logs
+logs
+*.log
+*.log.*
+
+# Dependency directories
+.pnpm
+dist
+build
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# GitHub Actions
+.github/*.log
+
+# Mac / OS
+.DS_Store


### PR DESCRIPTION
This PR adds a .gitignore file with standard rules for Node.js and GitHub Actions