### PR TITLE
fix: correct workflow to handle only PR events

### DIFF
--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,8 +1,6 @@
 name: Notify Slack Channel on Pull Request Updates
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
     types: [opened, closed, reopened]
@@ -25,6 +23,11 @@ jobs:
         env:
           SLACK_API_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_ACTION: ${{ github.event.action }}
+          PR_REVIEW_STATE: ${{ github.event.review.state }}
         run: |
           echo "Sending Slack notification..."
           node notify.js


### PR DESCRIPTION
What
- Restricts the workflow to run only on pull_request events (removes push).
- Adds missing environment variables (PR_TITLE, PR_URL, PR_AUTHOR, PR_ACTION, PR_REVIEW_STATE) Slack messages contain complete PR information.

Why
- The push trigger was causing the workflow to run twice, leading to duplicate Slack messages.  
- Missing PR environment variables resulted in incomplete notifications ("Unknown title/author").

How to test
1. Open a new PR in this repository.
2. Verify that only one workflow run is triggered.
3. Check Slack to confirm the notification contains the correct PR title, author, action, and URL.
